### PR TITLE
fix build with gcc13

### DIFF
--- a/src/slic3r/GUI/Gizmos/GLGizmoMeshBoolean.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMeshBoolean.cpp
@@ -211,7 +211,7 @@ void GLGizmoMeshBoolean::on_render_input_window(float x, float y, float bottom_l
 	*/
 
 	// ORCA match tab style
-	auto tab_button = [this](const wchar_t icon, bool selected, ImVec2 size, ImVec2 tab_padding, std::string& tooltip) {
+    auto tab_button = [this](const wchar_t icon, bool selected, ImVec2 size, ImVec2 tab_padding, const std::string& tooltip) {
 
 		std::string  str_label = std::string("");
         std::wstring btn_name  = icon + boost::nowide::widen(str_label);


### PR DESCRIPTION
Fix compilation error produced by GCC 13:

/home/dbuzdyk/packages/3d/OrcaSlicer/src/slic3r/GUI/Gizmos/GLGizmoMeshBoolean.cpp:306: error: no match for call to ‘(Slic3r::GUI::GLGizmoMeshBoolean::on_render_input_window(float, float, float)::<lambda(wchar_t, bool, ImVec2, ImVec2, std::string&)>) (const wchar_t&, bool, ImVec2&, ImVec2&, std::string)’
  306 |     if (tab_button(
      |     ~~~~~~~~~~~~~~~
  307 |                 m_is_dark_mode ? ImGui::MeshBooleanUnionDark : ImGui::MeshBooleanUnion,
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  308 |                 m_operation_mode == MeshBooleanOperation::Union,
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  309 |         tab_size,
      |         ~~~~~~~~~
  310 |                 tab_padding,
      |                 ~~~~~~~~~~~~
  311 |         _u8L("Union")
      |         ~~~~~~~~~~~~~
  312 |         )){
      |
/home/dbuzdyk/packages/3d/OrcaSlicer/src/slic3r/GUI/Gizmos/GLGizmoMeshBoolean.cpp:214: note: candidate: ‘Slic3r::GUI::GLGizmoMeshBoolean::on_render_input_window(float, float, float)::<lambda(wchar_t, bool, ImVec2, ImVec2, std::string&)>’ (near match)
  214 |         auto tab_button = [this](const wchar_t icon, bool selected, ImVec2 size, ImVec2 tab_padding, std::string& tooltip) {
      |
/home/dbuzdyk/packages/3d/OrcaSlicer/src/slic3r/GUI/Gizmos/GLGizmoMeshBoolean.cpp:214: note:   conversion of argument 5 would be ill-formed:
In file included from /home/dbuzdyk/packages/3d/OrcaSlicer/src/slic3r/GUI/Gizmos/GLGizmoBase.hpp:11,
                 from /home/dbuzdyk/packages/3d/OrcaSlicer/src/slic3r/GUI/Gizmos/GLGizmoMeshBoolean.hpp:4:
/home/dbuzdyk/packages/3d/OrcaSlicer/src/slic3r/GUI/I18N.hpp:7:54: error: cannot bind non-const lvalue reference of type ‘std::string&’ {aka ‘std::__cxx11::basic_string<char>&’} to an rvalue of type ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’}
    7 | #define _u8L(s)     Slic3r::GUI::I18N::translate_utf8((s))
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/home/dbuzdyk/packages/3d/OrcaSlicer/src/slic3r/GUI/Gizmos/GLGizmoMeshBoolean.cpp:311: note: in expansion of macro ‘_u8L’
  311 |         _u8L("Union")
      |